### PR TITLE
fix double-send of raw digit commands

### DIFF
--- a/uc_intg_skyq/remote.py
+++ b/uc_intg_skyq/remote.py
@@ -106,7 +106,6 @@ class SkyQRemote(RemoteEntity):
 
     async def _handle_send_cmd(self, command: str) -> StatusCodes:
         if command in DIGIT_COMMANDS:
-            self._device.buffer_digit(command)
             await self._device.cmd_send(command)
             return StatusCodes.OK
 


### PR DESCRIPTION
## Problem

Pressing a digit button (0–9) on a custom UI mapped to a raw digit command sends that digit twice: once immediately, then again ~2s later as a "digit buffer" flush that also appends `select`.

Multi-digit presses are worse — typing `1`, `2`, `3` produces:

```
20.417  send_cmd '1'  →  Socket Call 49
20.775  send_cmd '2'  →  Socket Call 50
21.152  send_cmd '3'  →  Socket Call 51
23.155  Digit buffer -> channel 123
23.158                  Socket Call 49  ← duplicate
23.687                  Socket Call 50  ← duplicate
24.218                  Socket Call 51  ← duplicate
25.046                  Socket Call 1   ← phantom select
```

Visible effect: the Sky box tunes to 123 from the live digits, then re-tunes to 123 again ~3 seconds later when the buffer flushes, plus a phantom `select` press at the end (which can activate whatever UI is on screen at that moment).

## Root cause

In `remote.py:_handle_send_cmd`, the digit path calls both `buffer_digit(command)` (which arms a 2s timer that re-sends digits + select via `cmd_change_channel`) and `cmd_send(command)` (immediate send). Both fire.

The `channel_select:XYZ` macro path is independent — it calls `cmd_change_channel` directly and never touched the buffer.

## Fix

Remove the `buffer_digit` call from the digit path. Raw digits now pass straight through. `channel_select:XYZ` is unaffected.

The buffer helpers in `device.py` (`buffer_digit`, `flush_digit_buffer`, `clear_digit_buffer`, `_process_digit_buffer`) become unreachable but are left in place to keep the diff minimal — happy to remove them in a follow-up if preferred.

## Verification

Built this branch as a `2.0.3` artifact and installed it on a Remote 3 connected to a Sky Q ES240. 
Confirmed:

- Single digit press (`1`) → one send, no buffer flush log
- Multi-digit (`1`, `2`, `3`) → three sends total, no duplication, no phantom select
- `channel_select:123` macro → digits + select sequence, unchanged
- Plain `select` press → single send, no buffer interaction